### PR TITLE
Updated README links, improved package metadata, Python 3.7 support, trusted publishing

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,121 @@
+name: Python Wheels
+
+on:
+  workflow_dispatch:
+  release:
+    types: ['released', 'prereleased']
+
+env:
+  PACKAGE_VERSION: '0.1.3'
+  PACKAGE_NAME: pykz
+
+jobs:
+  # Build the sdist and wheel distributions
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyPA build
+        run: python -m pip install -U pip build
+
+      - name: Build package
+        run: python -m build -o dist .
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: ./dist/*
+
+  # Testing is done in the official Python Docker container: https://hub.docker.com/_/python/
+  # This should match more closely to the environment that users might use.
+  test:
+    name: Run tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.12-bookworm
+      options: --user root  # Needed for apt-get
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install TeX Live
+        run: |
+          apt-get update
+          apt-get install -y texlive-latex-extra
+  
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+      - name: Install package
+        run: python -m pip install --find-links=dist "${PACKAGE_NAME}[dev]==${PACKAGE_VERSION}"
+
+      - name: Test
+        run: pytest -rP
+
+  # This step checks the package version before release (to make sure that the
+  # package version actually matches the version of the GitHub release tag),
+  # and uses Twine to check the metadata of the packages.
+  check-release:
+    name: Check release
+    if: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    container: python:3.12-bullseye
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+      - name: Install package
+        run: python -m pip install --no-deps --no-index --find-links=dist ${PACKAGE_NAME}==${PACKAGE_VERSION}
+
+      - name: Check package version
+        run: |
+          version="$(python -c 'from importlib.metadata import version as v; print(v("${{ env.PACKAGE_NAME }}"))')"
+          [ "${{ github.event.release.tag_name }}" = "$version" ]
+        shell: bash
+
+      - name: Twine check
+        run: |
+          python -m pip install twine
+          twine check dist/*
+
+  # Here we download the sdist and the built Wheel files, and upload them to
+  # TestPyPI. You should follow the trusted publishing instructions in the
+  # https://github.com/pypa/gh-action-pypi-publish README and on
+  # https://docs.pypi.org/trusted-publishers carefully!
+  release:
+    name: Release
+    needs: [check-release]
+    if: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/${PACKAGE_NAME}
+    permissions:
+      id-token: write  # mandatory for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -96,7 +96,7 @@ jobs:
           twine check dist/*
 
   # Here we download the sdist and the built Wheel files, and upload them to
-  # TestPyPI. You should follow the trusted publishing instructions in the
+  # PyPI. You should follow the trusted publishing instructions in the
   # https://github.com/pypa/gh-action-pypi-publish README and on
   # https://docs.pypi.org/trusted-publishers carefully!
   release:
@@ -105,8 +105,8 @@ jobs:
     if: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/${PACKAGE_NAME}
+      name: pypi
+      url: https://pypi.org/p/${PACKAGE_NAME}
     permissions:
       id-token: write  # mandatory for trusted publishing
     steps:
@@ -117,5 +117,3 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -6,7 +6,7 @@ on:
     types: ['released', 'prereleased']
 
 env:
-  PACKAGE_VERSION: '0.1.3'
+  PACKAGE_VERSION: '0.1.4'
   PACKAGE_NAME: pykz
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <div align="center">
     <h1>Pykz</h1>
     <b>A Python library to generate tikz code</b><br><br>
-<img alt="Static Badge" src="https://img.shields.io/badge/docs-examples-green?style=flat-square&link=https%3A%2F%2Fmathijssch.github.io%2Fpykz%2Fgallery%2Findex.html">
-<img alt="PyPI - Version" src="https://img.shields.io/pypi/v/pykz?style=flat-square&logo=pypi&color=green&link=https%3A%2F%2Fpypi.org%2Fproject%2Fpykz">
-<img alt="GitHub License" src="https://img.shields.io/github/license/mathijssch/pykz?style=flat-square&color=green">
-<br><br>
-</div> 
+
+[![Examples](https://img.shields.io/badge/docs-examples-green?style=flat-square)](https://mathijssch.github.io/pykz/gallery/index.html)
+[![PyPI](https://img.shields.io/pypi/v/pykz?style=flat-square&logo=pypi&color=green)](https://pypi.org/project/pykz)
+[![GitHub license](https://img.shields.io/github/license/mathijssch/pykz?style=flat-square&color=green)](https://github.com/Mathijssch/pykz/blob/main/LICENSE)<br><br>
+
+</div>
 
 Generate beautiful, publication-ready figures with the power of Tikz and pgfplots,
 with a comfortable, familiar Python syntax.
@@ -13,9 +14,9 @@ with a comfortable, familiar Python syntax.
 pykz aims to provide a syntax similar to matplotlib,
 but with the possibility of directly generating (and controlling!) your tikz code.
 
-The benefit over alternatives like [tikzplotlib](https://github.com/nschloe/tikzplotlib) is pykz was designed explicitly with pgfplots in mind,
+The benefit over alternatives like [tikzplotlib](https://github.com/nschloe/tikzplotlib) is that pykz was designed explicitly with pgfplots in mind,
 whereas the goal of tikzplotlib is to map matplotlib concepts to pgfplots.
-This is arguably more convenient if you already have code for matplotlib,
+The latter is arguably more convenient if you already have code for matplotlib,
 but it often still requires manual tweaking to the resulting tex-files.
 pykz aims to provide more control over the final output directly in Python,
 so no manual tweaking is required afterwards.
@@ -25,8 +26,8 @@ so no manual tweaking is required afterwards.
 ### Basic plotting
 
 Pykz has a simple, matplotlib-like interface for basic plotting.
-```
 
+```py
 import numpy as np
 import pykz
 
@@ -41,6 +42,7 @@ pykz.save("test-basic-plot.tex")
 # Save the Tikz code to a temporary file, compile it, and open the pdf in the default viewer.
 pykz.preview()
 ```
+
 <div align="center">
 <img src="https://mathijssch.github.io/pykz/_images/sphx_glr_basic_inline_001.png" alt="Sample output" width="60%">
 </div>
@@ -50,9 +52,9 @@ pykz.preview()
 Alternatively, you can use standard TikZ 
 drawing primitives, without using pfgplots.
 Options passed to the TikZ command are passed as keyword arguments.
-```
-import pykz
 
+```py
+import pykz
 
 rect = pykz.rectangle((-1, -1), (1, 1))
 circle = pykz.circle((2, 0), (1), fill="red")
@@ -62,12 +64,11 @@ rect2 = pykz.rectangle((1, 1), (2, 3), fill="cyan")
 # Dump the generated tikz code to the stdout.
 print(pykz.dumps())
 
-
 # Save the Tikz code to a temporary file, compile it, and open the pdf in the default viewer.
 pykz.preview()
 ```
 out: 
-```
+```tex
 \documentclass[tikz]{standalone}
 
 \begin{document}
@@ -79,7 +80,9 @@ out:
 \end{tikzpicture}
 \end{document}
 ```
+
 <div align="center">
 <img src="https://mathijssch.github.io/pykz/_images/sphx_glr_circles_and_squares_001.png" alt="Sample output" width="60%">
 </div>
-For more examples, visit the [online documentation]()
+
+More examples can be found in the [online documentation](https://mathijssch.github.io/pykz).

--- a/pykz/__init__.py
+++ b/pykz/__init__.py
@@ -1,3 +1,9 @@
+"""
+A Matplotlib-like interface for generating Tikz and Pgfplots figures
+"""
+
+__version__ = "0.1.3"
+
 from .api import (
     gcf,
     gca,

--- a/pykz/__init__.py
+++ b/pykz/__init__.py
@@ -2,7 +2,7 @@
 A Matplotlib-like interface for generating Tikz and Pgfplots figures
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from .api import (
     gcf,

--- a/pykz/api.py
+++ b/pykz/api.py
@@ -1,5 +1,7 @@
 """Public API"""
 
+from __future__ import annotations
+
 from .environments.axis import Axis
 from .environments.tikzpicture import TikzPicture
 from .commands.addplot import Addplot
@@ -9,7 +11,7 @@ from .commands.draw import Draw
 from .commands.circle import Circle
 from .plot import create_plot
 import numpy as np
-from typing import Optional
+from typing import Optional, Union
 
 
 class WorkSpace:
@@ -515,7 +517,7 @@ def axvline(x: float, ax: Axis = None, **options) -> list[Addplot]:
     return plot(xes, ys, ax=ax, **options)
 
 
-Point = np.ndarray | str | Node
+Point = Union[np.ndarray, str, Node]
 
 
 def __create_draw(connector_type: str, points: list[Point], **options) -> Draw:

--- a/pykz/command.py
+++ b/pykz/command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .tikzcode import Tex
 from .options import OptionsMixin
 

--- a/pykz/commands/circle.py
+++ b/pykz/commands/circle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .draw import Draw
 from .node import Node
 from .connector import Connector

--- a/pykz/commands/draw.py
+++ b/pykz/commands/draw.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..command import Command
 from .node import Node
 from ..formatting import format_vector

--- a/pykz/commands/node.py
+++ b/pykz/commands/node.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..command import Command
 from ..label import Label
 from ..tikzcode import Tex

--- a/pykz/commands/tikzset.py
+++ b/pykz/commands/tikzset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ..command import Command
 from ..style import Style
 from collections import OrderedDict

--- a/pykz/environment.py
+++ b/pykz/environment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from .tikzcode import TikzCode, Tex
 from .options import OptionsMixin

--- a/pykz/environments/axis.py
+++ b/pykz/environments/axis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from ..environment import Environment

--- a/pykz/plot.py
+++ b/pykz/plot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from .commands.addplot import Addplot, Addplot3d
 from .constants import MAX_NUMBER

--- a/pykz/tikzcode.py
+++ b/pykz/tikzcode.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union
 from .formatting import format_options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,40 @@ authors = [
     { name="Mathijs Schuurmans", email="mathijs.schuurmans@optia.be" },
 ]
 readme = "README.md"
+license = { "file" = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
     "numpy>=1.9"
 ]
 dynamic = ["version", "description"]
+keywords = ["tikz", "plotting", "matplotlib", "pgfplots", "latex"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Text Processing :: Markup :: LaTeX",
+    "Topic :: Artistic Software",
+    "Topic :: Software Development :: Code Generators",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
+]
+
+[project.urls]
+"Documentation" = "https://mathijssch.github.io/pykz"
+"Source" = "https://github.com/Mathijssch/pykz"
+"Bug Tracker" = "https://github.com/Mathijssch/pykz/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,18 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "pykz"
-version = "0.1.3"
 authors = [
     { name="Mathijs Schuurmans", email="mathijs.schuurmans@optia.be" },
 ]
-description = "A Matplotlib-like interface for generating Tikz and Pgfplots figures"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "numpy>=1.9"
 ]
+dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
To enable trusted publishing:

In the pykz GitHub repository, go to _Settings_ > _Environments_ and create an environment named `pypi`. Optionally enable deployment protection rules etc.  
Then sign in to PyPI, click your user name in the top right and go to _Your projects_ > _pykz_ > _Publishing_. In the _Add a new publisher_ section, enter Owner=`Mathijssch`, Repository name=`pykz`, Workflow name=`wheels.yaml`, Environment name=`pypi` (should match the one you created on GitHub), and add the publisher.

To publish a new version, bump the version number in `pykz/__init__.py` and in `.github/workflows/wheels.yaml`, and then create a _Release_ on GitHub. The tag name should match the version in `__init__.py` exactly. This will automatically trigger the CI to push the package to PyPI (and it will also verify the links to the documentation etc. so they get a green checkmark on PyPI).