### PR TITLE
Introduce support of contour plots using `contourpy`

### DIFF
--- a/examples/contours.py
+++ b/examples/contours.py
@@ -1,0 +1,101 @@
+"""
+Countour plots
+=========================
+Generating contour plots directly from data.
+"""
+
+# %%
+# Support for contour plots directly from a table of precomputed data is
+# relatively limited in `pgfplots`. [Matplotlib](https://matplotlib.org/)
+# uses `contourpy` to generate contours out of a matrix of `z`-values.
+# Using the same underlying engine, `pykz` can bring this same type of plots
+# directly to pgfplots.
+
+# &&
+# We import the usual libraries.
+import numpy as np
+import pykz
+
+# &&
+# Let's generate some data. We do this in exactly the same way as you would using
+# Matplotlib.
+
+x = np.linspace(0, 1, 50)
+y = np.linspace(0, 1, 50)
+
+
+def f(x, y):
+    return np.sin(2 * np.pi * x) * np.cos(2 * np.pi * y)
+
+
+X, Y = np.meshgrid(x, y)
+Z = f(X, Y)
+
+# &&
+# By default, `pykz` picks the contour levels to draw by
+# dividing the range of `z`-values into equally spaced bins.
+
+contours = pykz.contour(X, Y, Z)
+pykz.xlabel("$x$")
+pykz.ylabel("$y$")
+
+# Export your tex code as a standalone file
+pykz.save("contour_plot.tex", standalone=True)
+# Build the pdf
+pykz.io.export_pdf_from_file("contour_plot.tex")
+# Or even output as an svg
+pykz.io.export_png_from_file("contour_plot.tex")
+
+# &&
+# Of course you can also customize the plot in all kinds of ways.
+# For instance, let us change the colormap and visualize the z-values
+# with a colorbar. Also, let us set the x and y limits to be tight.
+
+pykz.colorbar()
+pykz.gca().set_option("colormap name", "viridis")
+pykz.gca().enlarge_limits(0)
+
+# Export your tex code as a standalone file
+pykz.save("contour_plot_fancy.tex", standalone=True)
+# Optionally, build the pdf
+pykz.io.export_pdf_from_file("contour_plot_fancy.tex")
+# Or even output as an svg
+pykz.io.export_png_from_file("contour_plot_fancy.tex")
+
+
+# &&
+# Similarly, we can create filled contours. Let's get rid of the existing contour,
+# and replace it with a filled contour. Alternatively, we could of course just create
+# a new figure as well.
+# This time, let's also specify the contour levels we want to show,
+#
+for contour in contours:
+    pykz.gca().remove(contour)
+
+levels = np.linspace(-1, 1, 20)
+contourfs = pykz.contourf(X, Y, Z, levels=levels)
+
+# Export your tex code as a standalone file
+pykz.save("contour_plot_filled.tex", standalone=True)
+# Optionally, build the pdf
+pykz.io.export_pdf_from_file("contour_plot_filled.tex")
+# Or even output as an svg
+pykz.io.export_png_from_file("contour_plot_filled.tex")
+
+# &&
+# Or, we could go even further in customizing the appearance of the end result,
+# using options that get passed to the generated `pgfplots` `addplot` command.
+# Essentially any option that is recognized by `pgfplots` can be directly added here.
+#
+for contour in contourfs:
+    pykz.gca().remove(contour)
+
+levels = np.linspace(-1, 1, 20)
+contourfs = pykz.contourf(X, Y, Z, levels=levels, draw=True, fill_opacity=0.5)
+
+# Export your tex code as a standalone file
+pykz.save("contour_plot_filled_custom.tex", standalone=True)
+# Optionally, build the pdf
+pykz.io.export_pdf_from_file("contour_plot_filled_custom.tex")
+# Or even output as an svg
+pykz.io.export_png_from_file("contour_plot_filled_custom.tex")

--- a/pykz/__init__.py
+++ b/pykz/__init__.py
@@ -28,6 +28,7 @@ from .api import (
     ylabel,
     zlabel,
     contour,
+    contourf,
     xlim,
     ylim,
     axhline,

--- a/pykz/api.py
+++ b/pykz/api.py
@@ -12,6 +12,7 @@ from .commands.draw import Draw
 from .commands.circle import Circle
 from .calc import Calc
 from .plot import create_plot, create_surface_plot
+from .contour import create_contour, create_contourf, ContourFilled, Contour
 import numpy as np
 from typing import Optional, Union
 
@@ -787,11 +788,23 @@ def surf(
 
 def contour(
     x, y, z, ax: Axis | None = None, label: str | None = None, **options
-) -> Addplot:
+) -> list[Contour]:
     ax = ax if ax is not None else __get_or_create_ax()
-    ax.set_option("view", "{0}{90}")
-    options["contour gnuplot"] = True
-    return surf(x, y, z, ax, label, **options)
+    contours = create_contour(x, y, z, **options)
+    for contour in contours:
+        ax.add(contour)
+    return contours
+
+
+def contourf(
+    x, y, z, ax: Axis | None = None, label: str | None = None, **options
+) -> list[ContourFilled]:
+    ax = ax if ax is not None else __get_or_create_ax()
+    contours = create_contourf(x, y, z, **options)
+    for contour in contours:
+        ax.add(contour)
+    usetikzlibrary("fillbetween")
+    return contours
 
 
 def colorbar(ax: Axis | None = None):

--- a/pykz/api.py
+++ b/pykz/api.py
@@ -789,21 +789,30 @@ def surf(
 def contour(
     x, y, z, ax: Axis | None = None, label: str | None = None, **options
 ) -> list[Contour]:
+    from .util import get_extremes_safely
+
     ax = ax if ax is not None else __get_or_create_ax()
-    contours = create_contour(x, y, z, **options)
+    contours, levels = create_contour(x, y, z, **options)
     for contour in contours:
         ax.add(contour)
+    min, max = get_extremes_safely(levels)
+    ax.set_option("point meta min", min)
+    ax.set_option("point_meta_max", max)
     return contours
 
 
 def contourf(
     x, y, z, ax: Axis | None = None, label: str | None = None, **options
 ) -> list[ContourFilled]:
+    from .util import get_extremes_safely
+
     ax = ax if ax is not None else __get_or_create_ax()
-    contours = create_contourf(x, y, z, **options)
+    contours, levels = create_contourf(x, y, z, **options)
     for contour in contours:
         ax.add(contour)
-    usetikzlibrary("fillbetween")
+    min, max = get_extremes_safely(levels)
+    ax.set_option("point meta min", min)
+    ax.set_option("point_meta_max", max)
     return contours
 
 

--- a/pykz/api.py
+++ b/pykz/api.py
@@ -15,6 +15,7 @@ from .plot import create_plot, create_surface_plot
 from .contour import create_contour, create_contourf, ContourFilled, Contour
 import numpy as np
 from typing import Optional, Union
+from pathlib import Path
 
 
 class WorkSpace:
@@ -160,13 +161,15 @@ def preview(fig: TikzPicture | None = None):
     fig.preview()
 
 
-def save(filename: str, fig: TikzPicture | None = None, standalone: bool = False):
+def save(
+    filename: str | Path, fig: TikzPicture | None = None, standalone: bool = False
+):
     """
     Save the generated Tikz code to a file.
 
     Parameters
     ----------
-    filename : str
+    filename : str | Path
         The path to write the figure to.
         If the extension `.tex` or `.tikz` is not present, `.tex` is appended.
     fig : TikzPicture, optional
@@ -174,7 +177,6 @@ def save(filename: str, fig: TikzPicture | None = None, standalone: bool = False
     standalone : bool, optional
         Whether to save as a standalone document, by default False
     """
-
     fig = gcf() if fig is None else fig
     if fig is None:
         return

--- a/pykz/commands/addplot.py
+++ b/pykz/commands/addplot.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from ..command import Command
-from ..options import Options
+from ..options import Options, OptionsMixin
 from ..formatting import format_plot_command
 import numpy as np
 
 
-class __AddplotBase(Command):
+class __AddplotBase(Command, OptionsMixin):
     def __init__(
         self,
         data: np.ndarray,
@@ -26,6 +26,9 @@ class __AddplotBase(Command):
     def customize_label(self, **options):
         """Customize the options of the inline label"""
         self._label_opts.set_options(**options)
+
+    def set_table_option(self, key: str, value: str):
+        self._table_opts.set_option(key, value)
 
     def get_code(self) -> str:
         return format_plot_command(

--- a/pykz/contour.py
+++ b/pykz/contour.py
@@ -29,7 +29,7 @@ class ContourFilled(TikzCode):
             format_matrix(self.point_list[s:e], row_sep=r"\\")
             for s, e in zip(self.indices[:-1], self.indices[1:])
         ]
-        full_cycle = r"\\\n".join(formatted_lines)
+        full_cycle = "\n\\\\\n".join(formatted_lines)
         plot_cmd = Addplot(full_cycle, **self._options)
         self.add_line(plot_cmd)
 

--- a/pykz/contour.py
+++ b/pykz/contour.py
@@ -1,0 +1,118 @@
+import contourpy
+import numpy as np
+from .tikzcode import TikzCode, Tex
+from .plot import create_plot, Addplot
+from .formatting import format_matrix
+
+PointArray = np.ndarray  # a n x 2 array of points
+IndexArray = np.ndarray  # a n-array of indices
+
+
+class ContourFilled(TikzCode):
+    def __init__(
+        self,
+        point_list: PointArray,
+        indices: IndexArray,
+        relative_level: int,
+        **plot_options,
+    ):
+        super().__init__()
+        self.point_list = point_list
+        self.indices = indices
+        self.level = relative_level
+        self._options = dict(fill=True, color_of_colormap=self.level)
+        self._options.update(plot_options)
+        self.build_lines()
+
+    def build_lines(self):
+        formatted_lines = [
+            format_matrix(self.point_list[s:e], row_sep=r"\\")
+            for s, e in zip(self.indices[:-1], self.indices[1:])
+        ]
+        full_cycle = r"\\\n".join(formatted_lines)
+        plot_cmd = Addplot(full_cycle, **self._options)
+        self.add_line(plot_cmd)
+
+
+class Contour(TikzCode):
+    def __init__(self, point_list: list[PointArray], relative_level: int, **options):
+        super().__init__()
+        self.point_list = point_list
+        self.level = relative_level
+        self._options = dict(draw=True, fill="none", color_of_colormap=self.level)
+        self._options.update(options)
+        self.build_lines()
+
+    def build_lines(self):
+        for line in self.point_list:
+            self.add_line(self.create_plot_command(line))
+
+    def create_plot_command(self, line: PointArray):
+        plot_cmd = create_plot(line[:, 0], line[:, 1], None, **self._options)[0]
+        return plot_cmd
+
+
+def _default_levels(z: np.ndarray, n_levels=10):
+    zmin = z.min()
+    zmax = z.max()
+    return np.linspace(zmin, zmax, n_levels)
+
+
+def get_relative_level(level, lower, upper):
+    return round((level - lower) / (upper - lower) * 1000)
+
+
+def create_contourf(
+    x: np.ndarray,
+    y: np.ndarray,
+    z: np.ndarray,
+    levels: list[float] = None,
+    contour_options: dict | None = None,
+    **pgfplots_options,
+) -> list[ContourFilled]:
+    options = dict(fill_type=contourpy.FillType.OuterOffset)
+    if contour_options is not None:
+        options.update(contour_options)
+    generator = contourpy.contour_generator(x, y, z, **options)
+    levels = _default_levels(z) if levels is None else levels
+    level_min = np.min(levels)
+    level_max = np.max(levels)
+    contour_tex = []
+    for l1, l2 in zip(levels[:-1], levels[1:]):
+        points, indices = generator.filled(l1, l2)
+        print(f"shape: {indices[0].shape}")
+        relative_level = get_relative_level(l1, level_min, level_max)
+        contour_tex.extend(
+            [
+                ContourFilled(pts, indx, relative_level, **pgfplots_options)
+                for pts, indx in zip(points, indices)
+            ]
+        )
+    return contour_tex
+
+
+def create_contour(
+    x: np.ndarray,
+    y: np.ndarray,
+    z: np.ndarray,
+    levels: list[float] = None,
+    contour_options: dict | None = None,
+    **pgfplots_options,
+):
+    options = dict(fill_type=contourpy.FillType.OuterOffset)
+    if contour_options is not None:
+        options.update(contour_options)
+    generator = contourpy.contour_generator(
+        x, y, z, line_type=contourpy.LineType.Separate, **options
+    )
+    levels = _default_levels(z) if levels is None else levels
+    level_min = np.min(levels)
+    level_max = np.max(levels)
+    points = generator.multi_lines(levels)
+    contour_tex = [
+        Contour(
+            pts, get_relative_level(level, level_min, level_max), **pgfplots_options
+        )
+        for pts, level in zip(points, levels)
+    ]
+    return contour_tex

--- a/pykz/contour.py
+++ b/pykz/contour.py
@@ -59,10 +59,9 @@ def _default_levels(z: np.ndarray, n_levels=10):
 
 
 def get_relative_level(level, levels):
-    levels = np.asarray(levels)
-    finite = np.isfinite(levels)
-    lower = np.min(levels[finite])
-    upper = np.max(levels[finite])
+    from .util import get_extremes_safely
+
+    lower, upper = get_extremes_safely(levels)
     return round((level - lower) / (upper - lower) * 1000)
 
 
@@ -82,7 +81,7 @@ def create_contourf(
     contour_tex = []
     for l1, l2 in zip(levels[:-1], levels[1:]):
         points, indices = generator.filled(l1, l2)
-        print(f"shape: {indices[0].shape}")
+        # print(f"shape: {indices[0].shape}")
         relative_level = get_relative_level(l1, levels)
         contour_tex.extend(
             [
@@ -90,7 +89,7 @@ def create_contourf(
                 for pts, indx in zip(points, indices)
             ]
         )
-    return contour_tex
+    return contour_tex, levels
 
 
 def create_contour(
@@ -113,4 +112,4 @@ def create_contour(
         Contour(pts, get_relative_level(level, levels), **pgfplots_options)
         for pts, level in zip(points, levels)
     ]
-    return contour_tex
+    return contour_tex, levels

--- a/pykz/contour.py
+++ b/pykz/contour.py
@@ -58,7 +58,11 @@ def _default_levels(z: np.ndarray, n_levels=10):
     return np.linspace(zmin, zmax, n_levels)
 
 
-def get_relative_level(level, lower, upper):
+def get_relative_level(level, levels):
+    levels = np.asarray(levels)
+    finite = np.isfinite(levels)
+    lower = np.min(levels[finite])
+    upper = np.max(levels[finite])
     return round((level - lower) / (upper - lower) * 1000)
 
 
@@ -75,13 +79,11 @@ def create_contourf(
         options.update(contour_options)
     generator = contourpy.contour_generator(x, y, z, **options)
     levels = _default_levels(z) if levels is None else levels
-    level_min = np.min(levels)
-    level_max = np.max(levels)
     contour_tex = []
     for l1, l2 in zip(levels[:-1], levels[1:]):
         points, indices = generator.filled(l1, l2)
         print(f"shape: {indices[0].shape}")
-        relative_level = get_relative_level(l1, level_min, level_max)
+        relative_level = get_relative_level(l1, levels)
         contour_tex.extend(
             [
                 ContourFilled(pts, indx, relative_level, **pgfplots_options)
@@ -106,13 +108,9 @@ def create_contour(
         x, y, z, line_type=contourpy.LineType.Separate, **options
     )
     levels = _default_levels(z) if levels is None else levels
-    level_min = np.min(levels)
-    level_max = np.max(levels)
     points = generator.multi_lines(levels)
     contour_tex = [
-        Contour(
-            pts, get_relative_level(level, level_min, level_max), **pgfplots_options
-        )
+        Contour(pts, get_relative_level(level, levels), **pgfplots_options)
         for pts, level in zip(points, levels)
     ]
     return contour_tex

--- a/pykz/environment.py
+++ b/pykz/environment.py
@@ -20,6 +20,9 @@ class Environment(Tex, OptionsMixin):
     def add(self, content: Union[Tex, str]):
         self.content.add_line(content)
 
+    def remove(self, content: Tex | str) -> "TikzCode":
+        self.content.remove(content)
+
     def get_code(self) -> str:
         return wrap_env(self.name, self.content.get_code(), **self.options)
 

--- a/pykz/environments/tikzpicture.py
+++ b/pykz/environments/tikzpicture.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from .. import formatting
 from ..tikzcode import TikzCode
 from ..commands.tikzset import Tikzset
+from pathlib import Path
+
 # from ..command import Command
 from .. import environment as env
 from . import axis as ax
 
 
 class TikzPicture(env.Environment):
-
     def __init__(self, standalone: bool = True, **options):
         super().__init__("tikzpicture", **options)
         self.standalone = standalone
@@ -41,7 +42,7 @@ class TikzPicture(env.Environment):
         preamble = self.preamble.get_code()
         for content in self.content.lines:
             if isinstance(content, env.Environment):
-                preamble += (content.requirements.get_code())
+                preamble += content.requirements.get_code()
         return preamble
 
     def format_styles(self) -> str:
@@ -67,22 +68,25 @@ class TikzPicture(env.Environment):
 
         return preamble + content
 
-    def export(self, filename: str):
+    def export(self, filename: str | Path):
         # Create the file directory if it doesn't exist already.
         import os
-        parent = os.path.dirname(filename)
-        if parent:
-            os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-        if not filename.endswith(".tex") and \
-           not filename.endswith(".tikz"):
-            filename = filename + ".tex"
+        filename = Path(filename)
+
+        parent = filename.parent
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+        if filename.suffix not in (".tex", ".tikz"):
+            filename = filename.with_suffix(".tex")
 
         with open(filename, "w") as f:
             f.write(self.get_code())
 
     def preview(self):
         from ..io import preview_latex_doc
+
         is_standalone = self.standalone
         self.standalone = True
         prev = preview_latex_doc(self.get_code())

--- a/pykz/io.py
+++ b/pykz/io.py
@@ -93,14 +93,14 @@ def export_pdf_from_file(path: Pathlike) -> Path:
         )
     import os
 
-    basename = path.name
     for ext in {".aux", ".log"}:
         try:
-            print(f"Removing {basename + ext}")
-            os.remove(basename + ext)
+            aux_file_path = path.with_suffix(ext)
+            print(f"Removing {aux_file_path}")
+            os.remove(aux_file_path)
         except FileNotFoundError:
             ...
-    return Path(f"{basename}.pdf")
+    return path.with_suffix(".pdf")
 
 
 def export_png_from_file(input_file: Pathlike, **options) -> Path:
@@ -123,7 +123,7 @@ def export_png_from_file(input_file: Pathlike, **options) -> Path:
     import pdf2image
 
     pdf_file = export_pdf_from_file(input_file)
-    path = pdf_file.replace(".pdf", ".png")
+    path = pdf_file.with_suffix(".png")
     options["output_file"] = path
     pdf2image.convert_from_path(pdf_file, **options)
     return path

--- a/pykz/tikzcode.py
+++ b/pykz/tikzcode.py
@@ -67,6 +67,9 @@ class TikzCode:
     def draw(self, *coordinates, **options) -> "TikzCode":
         return self.__cmd(f"\\draw{format_options(**options)} {'--'.join(coordinates)};")
 
+    def fill(self, *coordinates, **options) -> "TikzCode":
+        return self.__cmd(f"\\draw{format_options(**options)} {'--'.join(coordinates)};")
+
     def add_line(self, line: Tex | str) -> "TikzCode":
         if isinstance(line, str):
             line = Tex(line)

--- a/pykz/tikzcode.py
+++ b/pykz/tikzcode.py
@@ -5,7 +5,6 @@ from .formatting import format_options
 
 
 class Tex:
-
     def __init__(self, code: str):
         self.code = code
 
@@ -54,21 +53,35 @@ class TikzCode:
         argcnt = f"[{n_args}]" if n_args > 0 else ""
         return self.__cmd(f"\\newcommand{{\\{command}}}{argcnt}{{{definition}}}")
 
-    def node(self,
-             label_text: str, name: str = "", location: Union[tuple, str] = "",
-             **options) -> "TikzCode":
+    def node(
+        self,
+        label_text: str,
+        name: str = "",
+        location: Union[tuple, str] = "",
+        **options,
+    ) -> "TikzCode":
         location_str = f"at {location}" if location else ""
-        return self.__cmd(f"\\node{format_options(**options)} ({name}) {location_str} {{{label_text}}};")
+        return self.__cmd(
+            f"\\node{format_options(**options)} ({name}) {location_str} {{{label_text}}};"
+        )
 
-    def coordinate(self, name: str = "", location: Union[tuple, str] = "", **options) -> "TikzCode":
+    def coordinate(
+        self, name: str = "", location: Union[tuple, str] = "", **options
+    ) -> "TikzCode":
         location_str = f"at {location}" if location else ""
-        return self.__cmd(f"\\coordinate{format_options(**options)} ({name}) {location_str};")
+        return self.__cmd(
+            f"\\coordinate{format_options(**options)} ({name}) {location_str};"
+        )
 
     def draw(self, *coordinates, **options) -> "TikzCode":
-        return self.__cmd(f"\\draw{format_options(**options)} {'--'.join(coordinates)};")
+        return self.__cmd(
+            f"\\draw{format_options(**options)} {'--'.join(coordinates)};"
+        )
 
     def fill(self, *coordinates, **options) -> "TikzCode":
-        return self.__cmd(f"\\draw{format_options(**options)} {'--'.join(coordinates)};")
+        return self.__cmd(
+            f"\\draw{format_options(**options)} {'--'.join(coordinates)};"
+        )
 
     def add_line(self, line: Tex | str) -> "TikzCode":
         if isinstance(line, str):
@@ -78,3 +91,10 @@ class TikzCode:
 
     def get_code(self) -> str:
         return "\n".join(line.get_code() for line in self.lines) + "\n"
+
+    def remove(self, line: Tex | str) -> "TikzCode":
+        if isinstance(line, str):
+            line = Tex(line)
+        if line in self.lines:
+            self.lines.remove(line)
+        return self

--- a/pykz/util.py
+++ b/pykz/util.py
@@ -1,3 +1,14 @@
+import numpy as np
+
+
+def get_extremes_safely(values):
+    values = np.asarray(values)
+    finite = np.isfinite(values)
+    lower = np.min(values[finite])
+    upper = np.max(values[finite])
+    return lower, upper
+
+
 def format_options(**options) -> str:
     opts = []
     for name, value in options.items():
@@ -8,7 +19,7 @@ def format_options(**options) -> str:
             opts.append(f"{name}={value}")
 
     if opts:
-        options_str = ',\n'.join(opts)
+        options_str = ",\n".join(opts)
         return f"[{options_str}]"
     return ""
 
@@ -18,4 +29,4 @@ def wrap_env(envname: str, wrapped: str, **options) -> str:
 
 
 def format_list(items):
-    return ', '.join([str(item) for item in items])
+    return ", ".join([str(item) for item in items])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ readme = "README.md"
 license = { "file" = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
-    "numpy>=1.9"
+    "numpy>=1.9", 
+    "contourpy"
 ]
 dynamic = ["version", "description"]
 keywords = ["tikz", "plotting", "matplotlib", "pgfplots", "latex"]


### PR DESCRIPTION
Contour plots are now available using `pykz.contour` and `pykz.contourf`. Behind the scenes, this uses `contourpy` to generate the contour paths. Some manual trickery using [`color of colormap`](https://tikz.dev/pgfplots/reference-markers#pgfp.color:of:colormap) is used to ensure the contours are getting colored based on the colormap in use. Using the direct approach of setting `meta expr=level` does not work as this does not seem to affect the draw and fill color of a path.

This fixes #4.